### PR TITLE
Could top.guoziyang:rpc-api:3.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/rpc-api/pom.xml
+++ b/rpc-api/pom.xml
@@ -11,5 +11,14 @@
 
     <artifactId>rpc-api</artifactId>
 
-
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+         
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/163944799-e6006d98-0581-4968-b10e-9b9215e9138b.png)
This figure presents the dependency tree between multiple modules in **_My-RPC-Framework_**. As shown in this figure, Library **_org.slf4j:slf4j-simple:jar:1.7.30_** in **_rpc-common, rpc-core, rpc-api, test-server, test-client_** is inherited from their parent module. However, it is not used by **_rpc-api_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_rpc-api_**.

Specifically, the scope of **_org.slf4j:slf4j-simple:jar:1.7.30_** in **_rpc-api_** can be changed from **_compile_** to **_provided_**. The revisions in the pom are described as follows:
![image](https://user-images.githubusercontent.com/78527112/163945342-c454050e-7167-400c-98eb-e40effd6f7ff.png)
